### PR TITLE
Allow selecting a directory in "Add a directory"

### DIFF
--- a/src/mainwindow.cpp
+++ b/src/mainwindow.cpp
@@ -494,6 +494,7 @@ void MainWindow::on_comboBox_Dirs_currentIndexChanged(int index)
     if (index == 0) {
         QFileDialog dialog;
         dialog.setOption(QFileDialog::ShowDirsOnly, true);
+        dialog.setFileMode(QFileDialog::Directory);
 
         if (dialog.exec()) {
             QString path = dialog.directory().path();


### PR DESCRIPTION
The "Add a directory" dialog was using the default [`QFileMode`](https://doc.qt.io/qt-5/qfiledialog.html#FileMode-enum), which only permits selecting files. Configure it to allow directory selection with the `QFileDialog::Directory` mode.